### PR TITLE
Changes with phoenix 1.5.0

### DIFF
--- a/myapp/lib/myapp_web/live/deploy_live.ex
+++ b/myapp/lib/myapp_web/live/deploy_live.ex
@@ -1,0 +1,41 @@
+defmodule MyappWeb.DeployLive do
+  use MyappWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, deploy_step: "Ready!")}
+  end
+
+  def handle_event("github_deploy", _value, socket) do
+    #:ok = MyappWeb.start_deploy()
+    IO.puts "foo" ; :timer.sleep(1000); IO.puts "bar"
+    send(self(), :create_org)
+    {:noreply, assign(socket, deploy_step: "Starting deploy...")}
+  end
+
+  def handle_info(:create_org, socket) do
+  #  {:ok, org} = MyappWeb.create_org()
+  IO.puts "foo" ; :timer.sleep(1000); IO.puts "bar"
+    send(self(), {:create_repo, "org"})
+    {:noreply, assign(socket, deploy_step: "Creating GitHub org...")}
+  end
+
+  def handle_info({:create_repo, repo}, socket) do
+  #  {:ok, repo} = MyappWeb.create_repo(org)
+  IO.puts "foo" ; :timer.sleep(1000); IO.puts "bar"
+    send(self(), {:push_contents, "repo"})
+    {:noreply, assign(socket, deploy_step: "Creating GitHub repo...")}
+  end
+
+  def handle_info({:push_contents, repo}, socket) do
+   # :ok = MyappWeb.push_contents(repo)
+   IO.puts "foo" ; :timer.sleep(1000); IO.puts "bar"
+    send(self(), :done)
+    {:noreply, assign(socket, deploy_step: "Pushing to repo...")}
+  end
+
+  def handle_info(:done, socket) do
+    IO.puts "foo" ; :timer.sleep(1000); IO.puts "bar"
+    {:noreply, assign(socket, deploy_step: "Done!")}
+  end
+end

--- a/myapp/lib/myapp_web/live/deploy_live.html.leex
+++ b/myapp/lib/myapp_web/live/deploy_live.html.leex
@@ -1,0 +1,9 @@
+
+<div class="">
+  <div>
+    <div>
+      <button phx-click="github_deploy">Deploy to GitHub</button>
+    </div>
+    Status: <%= @deploy_step %>
+  </div>
+</div>

--- a/myapp/lib/myapp_web/router.ex
+++ b/myapp/lib/myapp_web/router.ex
@@ -18,6 +18,7 @@ defmodule MyappWeb.Router do
     pipe_through :browser
 
     live "/", PageLive, :index
+    live "/deploy", DeployLive, :index
   end
 
   # Other scopes may use custom stacks.

--- a/myapp/lib/myapp_web/templates/layout/root.html.leex
+++ b/myapp/lib/myapp_web/templates/layout/root.html.leex
@@ -18,6 +18,7 @@
             <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
               <li><%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
             <% end %>
+            <li><%= link "Live Deploy", to: Routes.deploy_path(@conn, :index) %></li>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">


### PR DESCRIPTION
Using https://elixirschool.com/blog/phoenix-live-view/ 
As a baseline, I found the changes in phoenix to make it not as straightforward. It was great otherwise and learnt a lot.

getting started now instead of having to do all those steps simply
```elixir
mix phx.new <app_name> --live
```
It does the exact plumbing this covers, so it might be good to keep it there.

On of the main differences is the controller setup. For the dashboard the template already implements a `PageController` and the namespacing seems different (it seems to prefer <MyApp+Web>.
also
```elixir
  use MyApp, :controller
  alias Phoenix.LiveView
```
gets replaced by the action
```elixir
  def live_view do
    quote do
      use Phoenix.LiveView,
        layout: {BalancedWeb.LayoutView, "live.html"}

      unquote(view_helpers())
    end
  end
```
which I think possibly is the recommended way to go now?
In the new template page is replaced by a `page_live` version, which hooks into the search, I could either hook into the plumbing that was setup for me there already which is almost identical to the tutorial, or split of slightly with a new route.
I went with a new route just because I'm still a bit uneasy with how things work.

In the events in the tutorial there were
```elixir
def handle_info(:create_org, socket) do
  {:ok, org} = MyApp.create_org()
  send(self(), {:create_repo, org})
  {:noreply, assign(socket, deploy_step: "Creating GitHub org...")}
end
```
functions that it looks to do something, I might have missed that step somewhere but it looks like it was getting ready for part 2 of the tutorial which is fine, for just this part (and to get it working) I could either create empty stub of that method or just hardcode those pieces. 
For myself I just hardcoded those pieces, feel free to remove or change it


it seems like everything else was 👌 on point